### PR TITLE
Add input checks for pipaux tables (draft)

### DIFF
--- a/R/check-inputs.R
+++ b/R/check-inputs.R
@@ -1,0 +1,106 @@
+#' Check input columns
+#'
+#' `check_inputs_columns()` checks if a table has the correct columns. It fails
+#' if there are any column names that don't belong in the table *or* if there
+#' any columns that should be in the table but aren't found. If any errors are
+#' found the function returns a bullet list with all errors.
+#'
+#' @param df data.frame: A table to check.
+#' @param cols character: A vector with correct column names.
+#' @param table_name character: The name of the table.
+#'
+#' @noRd
+check_inputs_columns <- function(df, cols, table_name){
+
+  msg <- sprintf('`%s` doesn\'t have the correct columns:', table_name)
+  nms <- names(df)
+
+  if (!all(nms %in% cols) | !all(cols %in% nms)) {
+    # Columns that don't belong
+    non_valid_cols <- nms[!nms %in% cols]
+    # Columns that must be in the table
+    missing_cols <- cols[!cols %in% nms]
+    # Create a bullet list vector
+    n_error <- length(non_valid_cols) + length(missing_cols)
+    tmp <- rep(NA, n_error)
+    for (i in seq_along(n_error)) {
+      tmp[i] <- sprintf('`%s` is not a valid column.', non_valid_cols[i])
+    }
+    for (i in seq_along(missing_cols)) {
+      tmp[i + length(non_valid_cols)] <- sprintf('`%s` is missing.' , missing_cols[i])
+    }
+    # Add 'x' as prefix
+    names(tmp) <- rep('x', n_error)
+    # Stop message
+    rlang::abort(c(msg, tmp))
+  }
+}
+
+#' Check input column types
+#'
+#' `check_inputs_column_types()` checks if a table has the correct column types.
+#' If any errors are found the function returns a bullet list with all errors.
+#'
+#' @param df data.frame: A table to check.
+#' @param cols character: A vector with correct column names.
+#' @param col_types character: A vector with correct column types.
+#' @param table_name character: The name of the table.
+#'
+#' @noRd
+check_inputs_column_types <- function(df, cols, col_types, table_name){
+
+  msg <- sprintf('`%s` doesn\'t have the correct column types:', table_name)
+  check <- vapply(df, class, FUN.VALUE = character(1), USE.NAMES = FALSE)
+
+  if (!identical(col_types, check)) {
+    # Create a bullet list vector
+    msg2 <- '`%s` must be a %s vector; not %s.'
+    n_error <- sum(col_types != check)
+    which_error <- which(col_types != check)
+    tmp <- rep(NA, n_error)
+    for (i in seq_along(which_error)) {
+      tmp[i] <- sprintf(msg2, cols[which_error][i], col_types[which_error][i], check[which_error][i])
+    }
+    # Add 'x' as prefix
+    names(tmp) <- rep('x', n_error)
+    # Stop message
+    rlang::abort(c(msg, tmp))
+  }
+}
+
+#' check_inputs_gdp_table
+#' @param gdp_table data.frame: The GDP table from pipaux.
+#' @return logical
+#' @noRd
+check_inputs_gdp_table <- function(gdp_table) {
+  cols <- c('country_code', 'year', 'gdp_data_level', 'gdp', 'gdp_domain')
+  col_types <- c('character', 'numeric', 'character', 'numeric', 'character')
+  check_inputs_columns(gdp_table, cols, 'gdp_table')
+  gdp_table <- gdp_table[cols]
+  check_inputs_column_types(gdp_table, cols, col_types, 'gdp_table')
+}
+
+#' check_inputs_pce_table
+#' @param pce_table data.frame: The PCE table from pipaux.
+#' @return logical
+#' @noRd
+check_inputs_pce_table <- function(pce_table) {
+  cols <- c('country_code', 'year', 'pce_data_level', 'pce', 'pce_domain')
+  col_types <- c('character', 'numeric', 'character', 'numeric', 'character')
+  check_inputs_columns(pce_table, cols, 'pce_table')
+  pce_table <- pce_table[cols]
+  check_inputs_column_types(pce_table, cols, col_types, 'pce_table')
+}
+
+#' check_inputs_pop_table
+#' @param pop_table data.frame: The Population table from pipaux.
+#' @return logical
+#' @noRd
+check_inputs_pop_table <- function(pop_table) {
+  cols <- c('country_code', 'year', 'pop_data_level', 'pop', 'pop_domain')
+  col_types <- c('character', 'numeric', 'character', 'numeric', 'character')
+  check_inputs_columns(pop_table, cols, 'pop_table')
+  pop_table <- pop_table[cols]
+  check_inputs_column_types(pop_table, cols, col_types, 'pop_table')
+}
+

--- a/tests/testthat/test-check-inputs.R
+++ b/tests/testthat/test-check-inputs.R
@@ -1,0 +1,88 @@
+# check_inputs_columns
+test_that('check_inputs_columns() works as expected', {
+  df <- data.frame(X1  = 'ABC', X2 = 2005)
+  cols <- c('X1')
+  expect_error(check_inputs_columns(df, cols, 'df'),
+               paste0('`df` doesn\'t have the correct columns:\n.*',
+                      '`X2` is not a valid column.'))
+  cols <- c('X1', 'X2', 'X3')
+  expect_error(check_inputs_columns(df, cols, 'df'),
+               paste0('`df` doesn\'t have the correct columns:\n.*',
+                      '`X3` is missing.'))
+  cols <- c('X1', 'X3')
+  expect_error(check_inputs_columns(df, cols, 'df'),
+               paste0('`df` doesn\'t have the correct columns:\n.*',
+                      '`X2` is not a valid column.\n.*`X3` is missing.'))
+})
+
+# check_inputs_column_types
+test_that('check_inputs_column_types() works as expected', {
+  df <- data.frame(X1  = 'ABC', X2 = '2005')
+  cols <- names(df)
+  col_types <- c('character', 'numeric')
+  expect_error(
+    check_inputs_column_types(df, cols, col_types, 'df'),
+    paste0('`df` doesn\'t have the correct column types:\n.*',
+           '`X2` must be a numeric vector; not character.'))
+  df <- data.frame(X1  = 'ABC', X2 = 2005, X3 = as.factor('I'))
+  cols <- names(df)
+  col_types <- c('factor', 'numeric', 'character')
+  expect_error(
+    check_inputs_column_types(df, cols, col_types, 'df'),
+    paste0('`df` doesn\'t have the correct column types:\n.*',
+           '`X1` must be a factor vector; not character.\n.*',
+           '`X3` must be a character vector; not factor.'))
+})
+
+# check_inputs_gdp_table
+test_that('check_inputs_gdp_table() works as expected', {
+  # Correct table
+  df <- data.frame(country_code = 'ABC', year = 2005, gdp_data_level = 'national',
+                   gdp_domain = 'national', gdp = 1000)
+  expect_null(check_inputs_gdp_table(df))
+  # Invalid column
+  df <- data.frame(country_code = 'ABC', year = '2005', gdp_data_level = 'national',
+                   gdp_domain = 'national', gdp = 1000, test = NA)
+  expect_error(check_inputs_gdp_table(df),
+               paste0('`gdp_table` doesn\'t have the correct columns:\n.*',
+                      '`test` is not a valid column.'))
+  # Missing column
+  df <- data.frame(country_code = 'ABC', year = '2005', gdp_data_level = 'national',
+                   gdp_domain = 1)
+  expect_error(check_inputs_gdp_table(df),
+               paste0('`gdp_table` doesn\'t have the correct columns:\n.*',
+                      '`gdp` is missing.'))
+  # Incorrect column type
+  df <- data.frame(country_code = 'ABC', year = '2005', gdp_data_level = 'national',
+                   gdp_domain = 'national', gdp = 1000)
+  expect_error(check_inputs_gdp_table(df),
+               paste0('`gdp_table` doesn\'t have the correct column types:\n.*',
+                      '`year` must be a numeric vector; not character.'))
+})
+
+# check_inputs_pce_table
+test_that('check_inputs_pce_table() works as expected', {
+  # Correct table
+  df <- data.frame(country_code = 'ABC', year = 2005, pce_data_level = 'national',
+                   pce_domain = 'national', pce = 1000)
+  expect_null(check_inputs_pce_table(df))
+  # Invalid column
+  df <- data.frame(country_code = 'ABC', year = '2005', pce_data_level = 'national',
+                   pce_domain = 'national', pce = 1000, test = NA)
+  expect_error(check_inputs_pce_table(df),
+               paste0('`pce_table` doesn\'t have the correct columns:\n.*',
+                      '`test` is not a valid column.'))
+  # Missing column
+  df <- data.frame(country_code = 'ABC', year = '2005', pce_data_level = 'national',
+                   pce_domain = 1)
+  expect_error(check_inputs_pce_table(df),
+               paste0('`pce_table` doesn\'t have the correct columns:\n.*',
+                      '`pce` is missing.'))
+  # Incorrect column type
+  df <- data.frame(country_code = 'ABC', year = '2005', pce_data_level = 'national',
+                   pce_domain = 'national', pce = 1000)
+  expect_error(check_inputs_pce_table(df),
+               paste0('`pce_table` doesn\'t have the correct column types:\n.*',
+                      '`year` must be a numeric vector; not character.'))
+})
+


### PR DESCRIPTION
Hi @tonyfujs,

Here is the input validation checks I have written to test the GDP, PCE and other tables as they enter the pipeline. Not sure if we want these `pipdm` or somewhere else, but thought I could share the code. 

Note: This PR does not include checks for all tables, but we could easily expand this to the PPP, CPI and PFW tables as well.

Let me know what you think. 

Thanks,
Aleksander 