### PR TITLE
Add comparable spell

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pipdm
 Title: PIP Data Managment
-Version: 0.0.1.9015
+Version: 0.0.1.9016
 Authors@R: 
     c(person(given = "Tony",
             family = "Fujs",

--- a/R/db_create_ref_year_table.R
+++ b/R/db_create_ref_year_table.R
@@ -35,6 +35,7 @@ db_create_ref_year_table <- function(gdp_table,
                                          'wb_region_code')) {
 
   # CHECKS
+  region_code <- match.arg(region_code)
   check_inputs_ref_years(ref_years)
   check_inputs_pip_years(pip_years)
 

--- a/R/db_finalize_ref_year_table.R
+++ b/R/db_finalize_ref_year_table.R
@@ -91,7 +91,7 @@ db_finalize_ref_year_table <- function(dt, pfw_table) {
             'pcn_region_code', 'country_code', 'reference_year',
             'surveyid_year', 'survey_year', 'survey_acronym',
             'survey_coverage', 'survey_comparability',
-            'welfare_type', 'survey_mean_lcu',
+            'comparable_spell', 'welfare_type', 'survey_mean_lcu',
             'survey_mean_ppp', 'predicted_mean_ppp',
             'ppp', 'pop', 'gdp', 'pce',
             'pop_data_level', 'gdp_data_level',


### PR DESCRIPTION
This finalizes solution to https://github.com/PIP-Technical-Team/pipapi/issues/35

Will run pipeline with updated code tomorrow.

cc: @tonyfujs, @randrescastaneda  

* Add comparable_spell column to SM and IM tables
* Bump version number
* Add match.arg for region_code to db_create_ref_year_table()
* Commented out joyn check for IND, IDN, CHN in db_create_dsm_table() since it interferes with running the code for testing / dev purposes (also don't think we need this check here).  