### PR TITLE
Remove gc parameter

### DIFF
--- a/R/db_clean_data.R
+++ b/R/db_clean_data.R
@@ -4,10 +4,9 @@
 #' and `wbpip:::gd_clean_data()`.
 #'
 #' @param dt data.table: A survey dataset.
-#' @param gc logical: If TRUE garbage collection is forced.
 #' @return data.table
 #' @export
-db_clean_data <- function(dt, gc = FALSE) {
+db_clean_data <- function(dt) {
   tryCatch(
     expr = {
 
@@ -20,17 +19,11 @@ db_clean_data <- function(dt, gc = FALSE) {
       # Remove labels from each column
       dt[] <- lapply(dt, c)
 
-      # Garbage collection
-      if (gc) gc(verbose = FALSE)
-
       return(dt)
     }, # end of expr section
 
     error = function(e) {
       rlang::warn("Data cleaning failed. Returning NULL.")
-
-      # Garbage collection
-      if (gc) gc(verbose = FALSE)
 
       return(NULL)
     } # end of error

--- a/R/db_compute_dist_stats.R
+++ b/R/db_compute_dist_stats.R
@@ -8,24 +8,18 @@
 #' @param cache_id character: cache id to identify the right process
 #' @return list
 #' @export
-db_compute_dist_stats <- function(dt, mean_table, pop_table, cache_id, gc = FALSE) {
+db_compute_dist_stats <- function(dt, mean_table, pop_table, cache_id) {
   tryCatch(
     expr = {
 
       # Compute dist stats
       res <- compute_dist_stats(dt, mean_table, pop_table, cache_id)
 
-      # Garbage collection
-      if (gc) gc(verbose = FALSE)
-
       return(res)
     }, # end of expr section
 
     error = function(e) {
       rlang::warn("Distributional statistics caluclation failed. Returning NULL.")
-
-      # Garbage collection
-      if (gc) gc(verbose = FALSE)
 
       return(NULL)
     } # end of error

--- a/R/db_compute_lorenz.R
+++ b/R/db_compute_lorenz.R
@@ -6,7 +6,7 @@
 #'
 #' @inheritParams db_clean_data
 #' @export
-db_compute_lorenz <- function(dt, gc = FALSE) {
+db_compute_lorenz <- function(dt) {
   tryCatch(
     expr = {
       dist_type <- unique(dt$distribution_type)
@@ -29,7 +29,4 @@ db_compute_lorenz <- function(dt, gc = FALSE) {
       return(NULL)
     } # end of error
   ) # End of trycatch
-
-  # Garbage collection
-  if (gc) gc(verbose = FALSE)
 }

--- a/R/db_compute_survey_mean.R
+++ b/R/db_compute_survey_mean.R
@@ -8,9 +8,7 @@
 #'
 #' @return data.table
 #' @export
-db_compute_survey_mean <- function(dt,
-                                   gd_mean = NULL,
-                                   gc = FALSE) {
+db_compute_survey_mean <- function(dt, gd_mean = NULL) {
   tryCatch(
     expr = {
 
@@ -28,17 +26,11 @@ db_compute_survey_mean <- function(dt,
         )
       )
 
-      # Garbage collection
-      if (gc) gc(verbose = FALSE)
-
       return(dt)
     }, # end of expr section
 
     error = function(e) {
       rlang::warn("Survey mean caluclation failed. Returning NULL.")
-
-      # Garbage collection
-      if (gc) gc(verbose = FALSE)
 
       return(NULL)
     } # end of error

--- a/man/db_clean_data.Rd
+++ b/man/db_clean_data.Rd
@@ -4,12 +4,10 @@
 \alias{db_clean_data}
 \title{Clean survey data}
 \usage{
-db_clean_data(dt, gc = FALSE)
+db_clean_data(dt)
 }
 \arguments{
 \item{dt}{data.table: A survey dataset.}
-
-\item{gc}{logical: If TRUE garbage collection is forced.}
 }
 \value{
 data.table

--- a/man/db_compute_dist_stats.Rd
+++ b/man/db_compute_dist_stats.Rd
@@ -4,7 +4,7 @@
 \alias{db_compute_dist_stats}
 \title{Calculate distributional statistics}
 \usage{
-db_compute_dist_stats(dt, mean_table, pop_table, cache_id, gc = FALSE)
+db_compute_dist_stats(dt, mean_table, pop_table, cache_id)
 }
 \arguments{
 \item{dt}{data.table: A survey dataset.}
@@ -14,8 +14,6 @@ db_compute_dist_stats(dt, mean_table, pop_table, cache_id, gc = FALSE)
 \item{pop_table}{data.table: A table with population data.}
 
 \item{cache_id}{character: cache id to identify the right process}
-
-\item{gc}{logical: If TRUE garbage collection is forced.}
 }
 \value{
 list

--- a/man/db_compute_lorenz.Rd
+++ b/man/db_compute_lorenz.Rd
@@ -4,12 +4,10 @@
 \alias{db_compute_lorenz}
 \title{Compute Lorenz}
 \usage{
-db_compute_lorenz(dt, gc = FALSE)
+db_compute_lorenz(dt)
 }
 \arguments{
 \item{dt}{data.table: A survey dataset.}
-
-\item{gc}{logical: If TRUE garbage collection is forced.}
 }
 \description{
 Calculate points on the Lorenz curve for a single survey dataset.

--- a/man/db_compute_survey_mean.Rd
+++ b/man/db_compute_survey_mean.Rd
@@ -4,14 +4,12 @@
 \alias{db_compute_survey_mean}
 \title{Calculate survey means}
 \usage{
-db_compute_survey_mean(dt, gd_mean = NULL, gc = FALSE)
+db_compute_survey_mean(dt, gd_mean = NULL)
 }
 \arguments{
 \item{dt}{data.table: A survey dataset.}
 
 \item{gd_mean}{numeric: Mean to use for grouped data surveys.}
-
-\item{gc}{logical: If TRUE garbage collection is forced.}
 }
 \value{
 data.table


### PR DESCRIPTION
hi @randrescastaneda 
cc: @tonyfujs 

More cleaning: 

Another legacy feature in pipdm is the ability for force garbage collection for some calculations. This stems from the non-targets parallel (multisession) processing pipeline I wrote in the beginning of the year. It was kept as a non-harmful feature. But it shouldn't be needed for neither our current or upcoming {targets} implementations. 