### PR TITLE
Fix bugs in db_create_coverage_table() + new is_used_for_line_up procedure

### DIFF
--- a/R/create_cache_file.R
+++ b/R/create_cache_file.R
@@ -3,6 +3,7 @@
 #' Save a cleaned version of the survey data in the cache survey data directory.
 #'
 #' @inheritParams db_create_ref_year_table
+#' @param pfw_table data.table: A table with the price framework file.
 #' @param pipeline_inventory data.table: Pipeline inventory table.
 #' @param pip_data_dir character: Input folder for the raw survey data.
 #' @param cache_svy_dir character: Output folder for the cached survey data.

--- a/R/db_create_censoring_table.R
+++ b/R/db_create_censoring_table.R
@@ -3,14 +3,22 @@
 #' Create censoring table based on manual inputs recorded in the AUX data, as well as the regional coverage.
 #'
 #' @param censored list: List with manual provided countries or regions to censor.
-#' @param coverage_table data.table: Coverage table. Output of `db_create_coverage_table()`.
+#' @param coverage_list list: Coverage list. Output of `db_create_coverage_table()`.
 #' @param coverage_threshold numeric: Value with the threshold to censor regions based on their coverage (e.g 50 %).
 #'
 #' @export
-db_create_censoring_table <- function(censored, coverage_table, coverage_threshold) {
+db_create_censoring_table <- function(censored, coverage_list, coverage_threshold) {
 
-  # Filther by threshold
-  dt <- coverage_table[coverage < coverage_threshold]
+  # Censor WLD if LIC/LMIC coverage is less than threshold
+  coverage_list$incgrp %>% data.table::setnames('coverage', 'coverage_incgrp')
+  wld <- merge(coverage_list$region[pcn_region_code == "WLD"],
+               coverage_list$incgrp, by = 'reporting_year')
+  wld$coverage <- ifelse(wld$coverage_incgrp < coverage_threshold, 0, wld$coverage)
+  wld <- wld[, c('reporting_year', 'pcn_region_code', 'coverage')]
+  coverage_list$region[pcn_region_code == "WLD"] <- wld
+
+  # Filter by threshold
+  dt <- coverage_list$region[coverage < coverage_threshold]
   dt %>% data.table::setnames('pcn_region_code', 'region_code')
   dt$statistic <- 'all'
   dt$id <- with(dt, sprintf('%s_%s', region_code, reporting_year))

--- a/R/db_create_coverage_table.R
+++ b/R/db_create_coverage_table.R
@@ -32,7 +32,7 @@ db_create_coverage_table <- function(ref_year_table,
   dt <- ref_year_table[
     ,
     c(
-      "wb_region_code", "pcn_region_code",
+      "pcn_region_code", # "wb_region_code",
       "country_code", "reporting_year",
       "survey_year", "welfare_type",
       "pop_data_level", "reporting_level"
@@ -44,7 +44,7 @@ db_create_coverage_table <- function(ref_year_table,
            by = list(
              country_code, reporting_year,
              pop_data_level, welfare_type,
-             pcn_region_code, wb_region_code,
+             pcn_region_code, # wb_region_code,
              reporting_level
            )
   ]
@@ -110,7 +110,7 @@ db_create_coverage_table <- function(ref_year_table,
   # Create coverage column (current method)
   dt$coverage <- (abs(dt$reporting_year - dt$survey_year) <= 3 |
     abs(dt$reporting_year - dt$survey_year_2) <= 3)
-  dt$coverage <- data.table::fifelse(dt$coverage, 100, 0)
+  # dt$coverage <- data.table::fifelse(dt$coverage, 1, 0)
   dt[is.na(coverage), ]$coverage <- 0
 
   # ---- Calculate world and regional coverage ----
@@ -147,13 +147,14 @@ db_create_coverage_table <- function(ref_year_table,
     data.table::as.data.table()
   out_inc <-  out_inc[, c('reporting_year', 'incgroup_historical', 'coverage')]
 
-  # Combine
+  # Create output list
   out <- list(region = rbind(out_region, out_wld, out_tot),
-              incgrp = out_inc)
+              incgrp = out_inc,
+              country_year_coverage = dt)
 
   # Adjust digits
-  out$region$coverage <- round(out$region$coverage, digits)
-  out$incgrp$coverage <- round(out$incgrp$coverage, digits)
+  out$region$coverage <- round(out$region$coverage * 100, digits)
+  out$incgrp$coverage <- round(out$incgrp$coverage * 100, digits)
 
   return(out)
 }

--- a/R/db_create_coverage_table.R
+++ b/R/db_create_coverage_table.R
@@ -48,7 +48,7 @@ db_create_coverage_table <- function(ref_year_table,
              reporting_level
            )
   ]
-  dt$survey_year_2 <- dt$survey_year %>%
+  dt$survey_year_after <- dt$survey_year %>%
     regmatches(., gregexpr(", .*", .)) %>%
     gsub(", ", "", .) %>%
     ifelse(. == "character(0)", NA, .) %>%
@@ -57,6 +57,7 @@ db_create_coverage_table <- function(ref_year_table,
     gsub(", .*", "", dt$survey_year) %>%
     as.character() %>%
     as.numeric()
+  dt <- data.table::setnames(dt, 'survey_year', 'survey_year_before')
 
   # ---- Prepare Population table ----
 
@@ -108,8 +109,8 @@ db_create_coverage_table <- function(ref_year_table,
   dt <- dt[!is.na(pop), ]
 
   # Create coverage column (current method)
-  dt$coverage <- (abs(dt$reporting_year - dt$survey_year) <= 3 |
-    abs(dt$reporting_year - dt$survey_year_2) <= 3)
+  dt$coverage <- (abs(dt$reporting_year - dt$survey_year_before) <= 3 |
+    abs(dt$reporting_year - dt$survey_year_after) <= 3)
   # dt$coverage <- data.table::fifelse(dt$coverage, 1, 0)
   dt[is.na(coverage), ]$coverage <- 0
 

--- a/R/db_create_coverage_table.R
+++ b/R/db_create_coverage_table.R
@@ -6,11 +6,14 @@
 #' @param ref_year_table data.table: Full interpolated means table. Output of
 #'   `db_create_ref_year_table()`.
 #' @param cl_table data.table: Country list table with all WDI countries.
-#' @param incgrp_table data.table: Table with historical income groups for all WDI countries.
+#' @param incgrp_table data.table: Table with historical income groups for all
+#'   WDI countries.
 #' @inheritParams db_create_ref_year_table
 #' @param digits numeric: The number of digits the returned coverage numbers are
 #'   rounded by.
-#' @param special_countries character: A string with 3-letter country codes.
+#' @param urban_rural_countries character: A string with 3-letter country codes.
+#'   Countries where the coverage calculation is based on urban or rural
+#'   population numbers.
 #'
 #' @return list
 #' @export
@@ -20,7 +23,7 @@ db_create_coverage_table <- function(ref_year_table,
                                      incgrp_table,
                                      ref_years,
                                      digits = 2,
-                                     special_countries =
+                                     urban_rural_countries =
                                        c("ARG", "CHN", "IDN", "IND", "SUR")) {
 
   # ---- Prepare Reference year table ----
@@ -57,13 +60,13 @@ db_create_coverage_table <- function(ref_year_table,
 
   # ---- Prepare Population table ----
 
-  # Select national population estimates except for special countries
+  # Select national population estimates except for selected countries
   pop_table <- pop_table[(pop_data_level == "national" |
-    country_code %in% special_countries), ]
+    country_code %in% urban_rural_countries), ]
 
   # Remove national population estimates for selected countries
   pop_table <- pop_table[!(pop_data_level == "national" &
-    country_code %in% special_countries), ]
+    country_code %in% urban_rural_countries), ]
 
   # Select population estimates for selected reference years
   pop_table <- pop_table[year %in% ref_years, ]

--- a/R/db_create_dsm_table.R
+++ b/R/db_create_dsm_table.R
@@ -123,14 +123,10 @@ db_create_dsm_table <- function(lcu_table,
   dt$is_interpolated <- FALSE
 
   # Add is_used_for_line_up column
-  cc <- check_no_national_survey(dt) # Check for no national surveys
-  dt[, n_rl := .N, by = cache_id]    # Create number of rows per cache_id
-  check <- (dt$reporting_level == "national" & dt$n_rl == 1) |  # Surveys w/ national reporting level and no split by U/R domain (e.g USA)
-    (dt$reporting_level %in% c("urban", "rural") & dt$n_rl == 2) | # Surveys split by U/R domain (e.g. CHN, IND)
-    dt$country_code %in% cc  # Countries wo/ any national surveys (e.g. ARG, SUR)
-  dt[, is_used_for_line_up := ifelse(check, TRUE, FALSE)]
+  dt <- create_line_up_check(dt)
 
   # Add is_used_for_aggregation column
+  dt[, n_rl := .N, by = cache_id]
   dt[, is_used_for_aggregation := ifelse((dt$reporting_level %in% c("urban", "rural") & dt$n_rl == 2), TRUE, FALSE)]
   dt$n_rl <- NULL
 

--- a/R/db_create_lkup_table.R
+++ b/R/db_create_lkup_table.R
@@ -59,6 +59,9 @@ db_create_lkup_table <- function(dt, nac_table, ref_years, region_code) {
   # Add region_code column (based on argument input)
   dt$region_code <- dt[, .SD, .SDcols = region_code]
 
+  # Select rows relevant for the line-up
+  dt <- dt[is_used_for_line_up == TRUE]
+
   # Add reference year column
   dt <- dt %>% tidyr::expand_grid(reference_year = ref_years)
 

--- a/R/db_create_ref_estimation_table.R
+++ b/R/db_create_ref_estimation_table.R
@@ -88,7 +88,7 @@ db_create_ref_estimation_table <- function(ref_year_table, dist_table) {
     "cpi_data_level", "ppp_data_level",
     "distribution_type", "gd_type",
     "is_interpolated",
-    "is_used_for_aggregation",
+    "is_used_for_line_up",
     "estimation_type",
     "interpolation_id",
     "display_cp"

--- a/R/db_create_ref_estimation_table.R
+++ b/R/db_create_ref_estimation_table.R
@@ -88,7 +88,7 @@ db_create_ref_estimation_table <- function(ref_year_table, dist_table) {
     "cpi_data_level", "ppp_data_level",
     "distribution_type", "gd_type",
     "is_interpolated",
-    "is_used_for_line_up",
+    "is_used_for_line_up", "is_used_for_aggregation",
     "estimation_type",
     "interpolation_id",
     "display_cp"

--- a/R/db_create_ref_year_table.R
+++ b/R/db_create_ref_year_table.R
@@ -17,7 +17,6 @@ if (getRversion() >= "2.15.1") {
 #' @param gdp_table data.table: A table with GDP data.
 #' @param pce_table data.table: A table with PCE data.
 #' @param pop_table data.table: A table with population data.
-#' @param pfw_table data.table: A table with the price framework file.
 #' @param ref_years numeric: A vector with reference years.
 #' @param pip_years numeric: A vector with calender years used in PIP.
 #' @param region_code character: A value with the region code column to use.
@@ -28,7 +27,6 @@ db_create_ref_year_table <- function(dsm_table,
                                      gdp_table,
                                      pce_table,
                                      pop_table,
-                                     pfw_table,
                                      ref_years,
                                      pip_years,
                                      region_code =
@@ -67,7 +65,7 @@ db_create_ref_year_table <- function(dsm_table,
   dt_ref <- db_get_closest_surveys(dt_ref) # Select closets surveys
   dt_ref <- db_select_lineup_surveys(dt_ref) # Select lineup surveys
   dt_ref <- db_compute_predicted_means(dt_ref) # Calculate predicted means
-  dt_ref <- db_finalize_ref_year_table(dt_ref, pfw_table, pop_table) # Finalize table (select rows and columns)
+  dt_ref <- db_finalize_ref_year_table(dt_ref, pop_table) # Finalize table (select rows and columns)
 
   return(dt_ref)
 }

--- a/R/db_create_svy_estimation_table.R
+++ b/R/db_create_svy_estimation_table.R
@@ -93,7 +93,7 @@ db_create_svy_estimation_table <- function(dsm_table, dist_table, gdp_table, pce
     "cpi_data_level", "ppp_data_level",
     "distribution_type", "gd_type",
     "is_interpolated",
-    "is_used_for_aggregation",
+    "is_used_for_line_up",
     "estimation_type",
     "display_cp"
   )

--- a/R/db_create_svy_estimation_table.R
+++ b/R/db_create_svy_estimation_table.R
@@ -93,7 +93,7 @@ db_create_svy_estimation_table <- function(dsm_table, dist_table, gdp_table, pce
     "cpi_data_level", "ppp_data_level",
     "distribution_type", "gd_type",
     "is_interpolated",
-    "is_used_for_line_up",
+    "is_used_for_line_up", "is_used_for_aggregation",
     "estimation_type",
     "display_cp"
   )

--- a/R/db_finalize_ref_year_table.R
+++ b/R/db_finalize_ref_year_table.R
@@ -15,7 +15,7 @@ if (getRversion() >= "2.15.1") {
 #'
 #' @return data.table
 #' @keywords internal
-db_finalize_ref_year_table <- function(dt, pfw_table, pop_table) {
+db_finalize_ref_year_table <- function(dt, pop_table) {
 
   # CHECK inputs
   check_inputs_db_class(dt)

--- a/R/db_finalize_ref_year_table.R
+++ b/R/db_finalize_ref_year_table.R
@@ -98,7 +98,7 @@ db_finalize_ref_year_table <- function(dt, pop_table) {
     "pce_data_level", "cpi_data_level",
     "ppp_data_level", "reporting_level", "distribution_type",
     "gd_type", "is_interpolated",
-    "is_used_for_line_up",
+    "is_used_for_line_up", "is_used_for_aggregation",
     "estimation_type",
     "display_cp"
   )

--- a/R/db_finalize_ref_year_table.R
+++ b/R/db_finalize_ref_year_table.R
@@ -79,8 +79,8 @@ db_finalize_ref_year_table <- function(dt, pfw_table, pop_table) {
   # aggregated numbers
   dt$predicted_mean_ppp <- data.table::fifelse(
     dt$is_interpolated &
-      dt$pop_data_level == "national" &
-      dt$is_used_for_aggregation,
+      dt$reporting_level == "national" &
+      dt$is_used_for_line_up,
     NA_real_,
     dt$predicted_mean_ppp
   )
@@ -98,7 +98,7 @@ db_finalize_ref_year_table <- function(dt, pfw_table, pop_table) {
     "pce_data_level", "cpi_data_level",
     "ppp_data_level", "reporting_level", "distribution_type",
     "gd_type", "is_interpolated",
-    "is_used_for_aggregation",
+    "is_used_for_line_up",
     "estimation_type",
     "display_cp"
   )
@@ -119,9 +119,9 @@ db_finalize_ref_year_table <- function(dt, pfw_table, pop_table) {
     )
 
   # change factors to characters
-  nn <- names(dt[, .SD, .SDcols = is.factor])
-  dt[, (nn) := lapply(.SD, as.character),
-         .SDcols = nn]
+  # nn <- names(dt[, .SD, .SDcols = is.factor])
+  # dt[, (nn) := lapply(.SD, as.character),
+  #        .SDcols = nn]
 
   # Sort rows
   data.table::setorder(dt, country_code, reporting_year, welfare_type, reporting_level)

--- a/R/process_svy_data_to_cache.R
+++ b/R/process_svy_data_to_cache.R
@@ -8,6 +8,7 @@
 #' @param compress numeric: Compression level used in `fst::write_fst()`.
 #' @inheritParams db_create_ref_year_table
 #' @inheritParams db_create_dsm_table
+#' @inheritParams create_cache_file
 #'
 #' @return data frame with status of process
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,30 @@
+#' Create boolean column for surveys to include in the reference year table creation
+#'
+#' @param dt data.table A table with survey metadata information.
+#' @return data.table
+#' @seealso `db_create_dsm_table()`
+#' @noRd
+create_line_up_check <- function(dt){
+
+  assertthat::assert_that(all(c("cache_id", "country_code", "reporting_level") %in% names(dt)))
+
+  # Countries wo/ any national (reporting level) surveys
+  cc <- check_no_national_survey(dt)
+
+  # Create number of rows per cache_id
+  dt[, n_rl := .N, by = cache_id]
+
+  # Create check
+  check <- (dt$reporting_level == "national" & dt$n_rl == 1) |  # Surveys w/ national reporting level and no split by U/R domain (e.g USA)
+    (dt$reporting_level %in% c("urban", "rural") & dt$n_rl == 2) | # Surveys split by U/R domain (e.g. CHN, IND)
+    dt$country_code %in% cc  # Countries wo/ any national surveys (e.g. ARG, SUR)
+
+  # Add is_used_for_line_up
+  dt$is_used_for_line_up <- ifelse(check, TRUE, FALSE)
+  dt$n_rl <- NULL
+
+  return(dt)
+}
 
 #' Find countries without national coverage
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,20 @@
+
+#' Find countries without national coverage
+#'
+#' @param df data.frame: A table with survey metadata information.
+#'
+#' @return character
+#' @seealso `db_create_lkup_table()`
+#' @noRd
+check_no_national_survey <- function(df) {
+  tmp <- table(df$country_code, df$reporting_level)
+  tmp <- as.data.frame(tmp, stringsAsFactors = FALSE)
+  names(tmp) <- c("country_code", "reporting_level", "freq")
+  cc <- tmp[(tmp$reporting_level == "national" & tmp$freq == 0), ][["country_code"]]
+  if (is.null(cc)) cc <- ""
+  return(cc)
+}
+
 #' check_inputs_ref_years
 #' @noRd
 check_inputs_ref_years <- function(x) {

--- a/man/db_create_censoring_table.Rd
+++ b/man/db_create_censoring_table.Rd
@@ -4,12 +4,12 @@
 \alias{db_create_censoring_table}
 \title{Create censoring table}
 \usage{
-db_create_censoring_table(censored, coverage_table, coverage_threshold)
+db_create_censoring_table(censored, coverage_list, coverage_threshold)
 }
 \arguments{
 \item{censored}{list: List with manual provided countries or regions to censor.}
 
-\item{coverage_table}{data.table: Coverage table. Output of \code{db_create_coverage_table()}.}
+\item{coverage_list}{list: Coverage list. Output of \code{db_create_coverage_table()}.}
 
 \item{coverage_threshold}{numeric: Value with the threshold to censor regions based on their coverage (e.g 50 \%).}
 }

--- a/man/db_create_coverage_table.Rd
+++ b/man/db_create_coverage_table.Rd
@@ -2,14 +2,16 @@
 % Please edit documentation in R/db_create_coverage_table.R
 \name{db_create_coverage_table}
 \alias{db_create_coverage_table}
-\title{Create coverage table}
+\title{Create coverage tables}
 \usage{
 db_create_coverage_table(
   ref_year_table,
   pop_table,
+  cl_table,
+  incgrp_table,
   ref_years,
   digits = 2,
-  special_countries = c("ARG", "CHN", "IDN", "IND")
+  special_countries = c("ARG", "CHN", "IDN", "IND", "SUR")
 )
 }
 \arguments{
@@ -18,6 +20,10 @@ db_create_coverage_table(
 
 \item{pop_table}{data.table: A table with population data.}
 
+\item{cl_table}{data.table: Country list table with all WDI countries.}
+
+\item{incgrp_table}{data.table: Table with historical income groups for all WDI countries.}
+
 \item{ref_years}{numeric: A vector with reference years.}
 
 \item{digits}{numeric: The number of digits the returned coverage numbers are
@@ -25,6 +31,10 @@ rounded by.}
 
 \item{special_countries}{character: A string with 3-letter country codes.}
 }
+\value{
+list
+}
 \description{
-Create a table with coverage estimates at regional, WLD and TOT levels.
+Create a list of tables with coverage estimates at 1) regional, WLD, TOT and
+2) income group levels.
 }

--- a/man/db_create_ref_year_table.Rd
+++ b/man/db_create_ref_year_table.Rd
@@ -9,7 +9,6 @@ db_create_ref_year_table(
   gdp_table,
   pce_table,
   pop_table,
-  pfw_table,
   ref_years,
   pip_years,
   region_code = c("pcn_region_code", "wb_region_code")
@@ -23,8 +22,6 @@ db_create_ref_year_table(
 \item{pce_table}{data.table: A table with PCE data.}
 
 \item{pop_table}{data.table: A table with population data.}
-
-\item{pfw_table}{data.table: A table with the price framework file.}
 
 \item{ref_years}{numeric: A vector with reference years.}
 

--- a/man/db_finalize_ref_year_table.Rd
+++ b/man/db_finalize_ref_year_table.Rd
@@ -4,12 +4,10 @@
 \alias{db_finalize_ref_year_table}
 \title{Finalize reference year table}
 \usage{
-db_finalize_ref_year_table(dt, pfw_table, pop_table)
+db_finalize_ref_year_table(dt, pop_table)
 }
 \arguments{
 \item{dt}{data.table: Output of \code{\link[=db_compute_predicted_means]{db_compute_predicted_means()}}.}
-
-\item{pfw_table}{data.table: A table with the price framework file.}
 
 \item{pop_table}{data.table: A table with population data.}
 }

--- a/man/find_new_svy_data.Rd
+++ b/man/find_new_svy_data.Rd
@@ -4,12 +4,7 @@
 \alias{find_new_svy_data}
 \title{Find which data is not available in cache folder or has changed SVY ID}
 \usage{
-find_new_svy_data(
-  cache_id,
-  filename,
-  tool = c("PC", "TB"),
-  cache_svy_dir = NULL
-)
+find_new_svy_data(cache_id, filename, tool = c("PC", "TB"), cache_svy_dir)
 }
 \arguments{
 \item{cache_id}{character: vector with cache Ids from pipeline inventory}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,3 +1,30 @@
+# create_line_up_check
+test_that("create_line_up_check() works as expected", {
+  # Create test data
+  dt <- data.table(
+    cache_id = c('ARG_1980_EPH_D2_INC_GROUP', 'ARG_2002_EPH_D2_INC_GPWG', 'ARG_2018_EPHC-S2_D2_INC_GPWG',
+                 'IND_1977_NSS_D2_CON_GROUP', 'IND_1993_NSS-SCH1_D2_CON_GPWG', 'IND_2011_NSS-SCH1_D2_CON_GPWG',
+                 'IND_1977_NSS_D2_CON_GROUP', 'IND_1993_NSS-SCH1_D2_CON_GPWG', 'IND_2011_NSS-SCH1_D2_CON_GPWG',
+                 'URY_1981_ENH_D2_INC_GROUP', 'URY_1996_ECH_D2_INC_GPWG', 'URY_2006_ECH_D1_INC_GPWG',
+                 'USA_1974_CPS-LIS_D1_INC_BIN', 'USA_2001_CPS-LIS_D1_INC_BIN', 'USA_2018_CPS-ASEC-LIS_D1_INC_BIN'),
+    country_code = c(rep('ARG', 3), rep('IND', 6), rep('URY', 3), rep('USA', 3)),
+    reporting_level = c(rep('urban', 3), rep(c('urban', 'rural'), each = 3), c('urban', 'urban', 'national'),
+                        rep('national', 3))
+  )
+
+  res <- create_line_up_check(dt)
+  # If all surveys for a specfic country are national they should be included
+  expect_true(all(res[country_code == 'USA',]$is_used_for_line_up))
+  # If all surveys for a specfic country are non-national they should be included
+  expect_true(all(res[country_code == 'ARG',]$is_used_for_line_up))
+  # If surveys are split by U/R (domain = 2) they should be included
+  expect_true(all(res[country_code == 'IND',]$is_used_for_line_up))
+  # If a country has both national and urban/rural surveys than the latter should be discarded
+  expect_false(all(res[country_code == 'URY',]$is_used_for_line_up))
+  expect_true(all(!res[country_code == 'URY' & reporting_level != 'national',]$is_used_for_line_up))
+  expect_true(all(res[country_code == 'URY' & reporting_level == 'national',]$is_used_for_line_up))
+})
+
 # check_no_national_survey
 test_that("check_no_national_survey() works as expected", {
   df <- data.frame(


### PR DESCRIPTION
Hi @tonyfujs 

Here is a PR for the new `is_used_for_line_up` column and procedure + several fixes for the coverage and censoring calculations. 

For the coverage calculation the following important things have changed: 

* Add SUR as a special country
* Merge with cl_table to ensure that region_code is available for all countries
* Merge with incgrp table to calculate LIC/LMIC coverage

Note that I kept the `*_table()` name for the function and filename for the censoring and coverage functions, even though they now return lists. Partly because we have started moving files to the ingestion repo. But we could change that if you want. 

For the refyear table note the following: 

* `db_create_ref_year_table()` now filters surveys based on the `is_used_for_line_up` column. That means that the predicted mean is only calculated for 1) "normal" national surveys 2) U/R surveys when the "domain" is non-national and 3) urban _or_ rural surveys when there is no national survey  at all for a specific country
* For the rule to create `is_used_for_line_up`  see changes in `db_create_dsm_table()` 
*  `is_used_for_line_up` might not be a perfect name in case it is confused with selection of INC/CON surveys for the line up (but maybe it is good enough) 
* Removed pfw_table from `db_create_ref_year_table()` inputs (no longer used) 


**EDIT:** After taking  a look at the API code and thinking more about this: `is_used_for_line_up` and `is_used_for_aggregation` measure conceptually different things. I thus added a (modified) version of   `is_used_for_aggregation`  back into the output tables. I believe the only surveys that should be aggregated are the ones split by U/R domain (IND, CHN, IDN).  We need to take care that ARG is included in the lineup (meaning `is_used_for_line_up = TRUE` ) now does, but there is no need for any aggregation (`is_used_for_aggregation = FALSE`). 